### PR TITLE
Update head.html to have https font link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
 
 	<!-- CSS & fonts -->
 	<link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl | replace: '//', '/' }}">
-	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,900,400italic%7CSignika:700,300,400,600' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,900,400italic%7CSignika:700,300,400,600' rel='stylesheet' type='text/css'>
 
 	<!-- RSS -->
 	<link href="/atom.xml" type="application/atom+xml" rel="alternate" title="ATOM Feed" />


### PR DESCRIPTION
As [pointed out here](https://github.com/iandioch/cpssd.net/issues/17), using a `http` link gives a mixed content warning when the site is served over `https`. Seeing as `fonts.googleapis.com` is available with `https`, there is no downside to using it.