### PR TITLE
Footer sticks to the bottom

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,1 +1,1 @@
-<footer><span>@2015 - Emerald</span></footer>
+<footer class="footer"><span>@2015 - Emerald</span></footer>

--- a/_posts/2019-03-18-small-text.md
+++ b/_posts/2019-03-18-small-text.md
@@ -1,0 +1,4 @@
+---
+title: Small text
+---
+This is an example of a blog post with small amount of text.

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -1,5 +1,10 @@
 /* -- General Layout -- */
 
+/* Required for footer to stick to the bottom */
+html, body {
+	height: 100%;
+}
+
 /* Navigation */
 
 #nav, #nav-left { 
@@ -252,4 +257,20 @@ footer {
   color: $background-color;
   text-align: center;
   padding: 0.6667em 0;
+}
+
+#wrap {
+	min-height:100%; 
+	position:relative;
+	padding-bottom: 105px;
+}
+
+.footer {
+	padding: 25px 0;
+	background-color: $main-color;
+	color: $background-color;
+	text-align: center;
+	position: absolute;
+  width: 100%;
+  bottom: 0;
 }


### PR DESCRIPTION
Hello! 
I've been using this theme for a long time and the thing that I fixed immediately was the sticky footer.

Currently, the footer does not stick to the bottom of the page -
![sc1](https://i.imgur.com/v2RqPh2.png)
This can look weird with posts with small amount of text. I know that blogs with little text is bad, but that does not mean it should look funny.

I've implemented the sticky footer - 
![sc2](https://i.imgur.com/nw1mHPz.png)

This, of course, works on phones as well -
![sc3](https://i.imgur.com/Lz1DPLs.png)
